### PR TITLE
ci(docker): tag images with commit SHA in addition to latest

### DIFF
--- a/.github/workflows/docker_build_push.yml
+++ b/.github/workflows/docker_build_push.yml
@@ -20,6 +20,9 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
+    - name: Extract short commit SHA
+      run: echo "COMMIT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
     - name: Login to Docker registry
       uses: docker/login-action@v3
       with:
@@ -33,4 +36,6 @@ jobs:
         context: ${{ inputs.project_path }}
         file: ${{ inputs.dockerfile_path }}
         push: true
-        tags: ${{ secrets.DOCKER_REGISTRY_ENDPOINT }}/${{ inputs.image_name }}:latest
+        tags: |
+          ${{ secrets.DOCKER_REGISTRY_ENDPOINT }}/${{ inputs.image_name }}:latest
+          ${{ secrets.DOCKER_REGISTRY_ENDPOINT }}/${{ inputs.image_name }}:${{ env.COMMIT_SHA }}


### PR DESCRIPTION
Allows pinning a specific image version for deployment by referencing the immutable commit SHA tag (e.g. :4a1a7f2).