### PR TITLE
feat(frontend): add quick alert creation from token details page

### DIFF
--- a/frontend/app/components/CreateAlertModal.vue
+++ b/frontend/app/components/CreateAlertModal.vue
@@ -130,6 +130,9 @@ type AlertDisplayType = 'One-off';
 
 const props = defineProps<{
   open: boolean;
+  initialToken?: string;
+  initialNetwork?: string;
+  initialIsPrimaryMarket?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -244,6 +247,10 @@ watch(
     loadPrices().catch(() => {
       // errors are surfaced via pricesError; noop here
     });
+
+    if (props.initialToken) form.token_name = props.initialToken;
+    if (props.initialIsPrimaryMarket !== undefined) form.is_primary_market = props.initialIsPrimaryMarket;
+    if (props.initialNetwork) form.network = capitalize(props.initialNetwork);
   },
 );
 

--- a/frontend/app/pages/tokens/[token_name].vue
+++ b/frontend/app/pages/tokens/[token_name].vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { TableColumn } from '#ui/components/Table.vue';
 import { getTokenFullName } from '~/utils/tokens';
+import { ref } from 'vue';
 
 const route = useRoute();
 const tokenName = computed(() => route.params.token_name as string);
@@ -42,7 +43,19 @@ const columns: TableColumn<ApiToken>[] = [
     header: 'Premium',
     cell: ({ row }) => `${Number(row.getValue('premium_percentage')).toFixed(2)}%`,
   },
+  {
+    id: 'actions',
+    header: '',
+  },
 ] as const;
+
+const createAlertModalOpen = ref(false);
+const pendingAlertRow = ref<ApiToken | null>(null);
+
+const openCreateAlertModal = (token: ApiToken) => {
+  pendingAlertRow.value = token;
+  createAlertModalOpen.value = true;
+};
 
 const tokenNotFound = computed(
   () => !pending.value && !error.value && tokensForName.value.length === 0,
@@ -132,8 +145,26 @@ const lastUpdatedLabel = computed(() => {
             </div>
           </div>
         </template>
-        <UTable :data="secondaryMarkets" :columns="columns" />
+        <UTable :data="secondaryMarkets" :columns="columns">
+          <template #actions-cell="{ row }">
+            <UButton
+              size="xs"
+              variant="ghost"
+              icon="i-heroicons-bell-plus"
+              @click="openCreateAlertModal(row.original)"
+            >
+              New alert
+            </UButton>
+          </template>
+        </UTable>
       </UCard>
+
+      <CreateAlertModal
+        v-model:open="createAlertModalOpen"
+        :initial-token="pendingAlertRow?.token_name"
+        :initial-network="pendingAlertRow?.network"
+        :initial-is-primary-market="false"
+      />
 
     </template>
   </div>


### PR DESCRIPTION
## Summary

- Adds a **"New alert"** button on each row of the secondary market table in the token details page
- Clicking the button opens the create alert modal with token, network, and market type (`is_primary_market: false`) pre-filled
- Extends `CreateAlertModal` with optional `initialToken`, `initialNetwork`, and `initialIsPrimaryMarket` props for pre-population

Closes #35

## Changes

**`CreateAlertModal.vue`**
- Added 3 optional props: `initialToken?`, `initialNetwork?`, `initialIsPrimaryMarket?`
- Applied pre-fill values in the `open` watcher when the modal is opened

**`tokens/[token_name].vue`**
- Added an `actions` column to the secondary market table with a ghost "New alert" button per row
- Wires up `CreateAlertModal` with the selected row's data as initial values

## Test plan

- [ ] Navigate to a token details page (e.g. `/tokens/wsteth`)
- [ ] Verify a "New alert" button appears on each secondary market row
- [ ] Click the button and confirm the modal opens with the correct token, network, and market type pre-filled
- [ ] Verify the form is still fully editable after pre-fill
- [ ] Verify the modal resets to empty state after closing and reopening via the Alerts page

🤖 Generated with [Claude Code](https://claude.com/claude-code)